### PR TITLE
Process employee attendance punches

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,3 @@
 from . import employee_login
+from . import zk_machine_attendance
+from . import biometric_device_details

--- a/models/biometric_device_details.py
+++ b/models/biometric_device_details.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+################################################################################
+#
+#    Biometric Device Integration for Odoo
+#    Extended to support multiple calendars and night shifts with idempotency
+#
+################################################################################
+
+import datetime
+import time
+import logging
+import pytz
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from zk import ZK, const
+except Exception:  # pragma: no cover - optional dependency at runtime
+    ZK = None
+
+
+class BiometricDeviceDetails(models.Model):
+    _name = 'biometric.device.details'
+    _description = 'Biometric Device Details'
+
+    name = fields.Char(string='Name', required=True)
+    device_ip = fields.Char(string='Device IP', required=True)
+    port_number = fields.Integer(string='Port Number', required=True)
+    address_id = fields.Many2one('res.partner', string='Working Address')
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.user.company_id.id)
+    last_pull_at = fields.Datetime(string='Last Pull At')
+
+    def _get_connection_object(self):
+        if ZK is None:
+            raise UserError(_("Pyzk module not found. Please install it with 'pip3 install pyzk'."))
+        try:
+            return ZK(self.device_ip, port=self.port_number, timeout=30, password=0, ommit_ping=False)
+        except Exception as exc:  # defensive
+            raise UserError(str(exc))
+
+    def device_connect(self, zk):
+        try:
+            return zk.connect()
+        except Exception as e:
+            _logger.error("Connection failed: %s", e)
+            return False
+
+    def action_test_connection(self):
+        zk = self._get_connection_object()
+        try:
+            conn = zk.connect()
+            conn.disconnect()
+            return {'type': 'ir.actions.client', 'tag': 'display_notification',
+                    'params': {'message': 'Successfully Connected', 'type': 'success', 'sticky': False}}
+        except Exception as error:
+            raise ValidationError(f'{error}')
+
+    def action_set_timezone(self):
+        for info in self:
+            zk = info._get_connection_object()
+            conn = info.device_connect(zk)
+            if conn:
+                try:
+                    user_tz = self.env.context.get('tz') or self.env.user.tz or 'UTC'
+                    now_utc = pytz.utc.localize(fields.Datetime.now())
+                    user_time = now_utc.astimezone(pytz.timezone(user_tz))
+                    conn.set_time(user_time)
+                    conn.disconnect()
+                    return {
+                        'type': 'ir.actions.client',
+                        'tag': 'display_notification',
+                        'params': {
+                            'message': 'Successfully Set the Time',
+                            'type': 'success',
+                            'sticky': False
+                        }
+                    }
+                except Exception as e:
+                    raise UserError(_("Failed to set device time: %s") % str(e))
+            else:
+                raise UserError(_("Connection failed. Please check the device settings."))
+
+    def action_clear_attendance(self):
+        for info in self:
+            self._cr.execute("DELETE FROM zk_machine_attendance")
+
+    # --- Helpers ---
+    def _float_hour_to_time(self, float_hour):
+        if float_hour is None:
+            return None
+        hours = int(float_hour)
+        minutes = int(round((float_hour - hours) * 60))
+        if minutes >= 60:
+            hours += 1
+            minutes -= 60
+        return datetime.time(hours % 24, minutes)
+
+    def _get_employee_working_hours(self, employee, punch_date):
+        # Support either single or multi calendars
+        calendars = getattr(employee, 'resource_calendar_ids', False) or employee.resource_calendar_id
+        if not calendars:
+            return []
+        if isinstance(calendars, models.Model):
+            calendars = [calendars]
+        weekday = punch_date.weekday()
+        lines = self.env['resource.calendar.attendance']
+        for cal in calendars:
+            lines |= cal.attendance_ids.filtered(lambda a: int(a.dayofweek) == weekday)
+        return lines.sorted('hour_from')
+
+    def _select_shift_type(self, employee, punch_datetime):
+        punch_date = punch_datetime.date()
+        working_hours = self._get_employee_working_hours(employee, punch_date)
+        if not working_hours:
+            return 'night', [(datetime.time(16, 45), datetime.time(8, 45))]
+        slots = [(self._float_hour_to_time(s.hour_from), self._float_hour_to_time(s.hour_to)) for s in working_hours]
+        # Night shift if a slot crosses midnight
+        if slots[0][1] < slots[0][0]:
+            return 'night', slots
+        else:
+            return 'day', slots
+
+    # --- Core download and processing ---
+    def action_download_attendance(self):
+        start_time = time.time()
+        _logger.info("Downloading attendance...")
+
+        zk_attendance = self.env['zk.machine.attendance']
+        hr_attendance = self.env['hr.attendance']
+
+        today_local = fields.Date.context_today(self)
+        device_tz = pytz.timezone('Asia/Rangoon')
+
+        for info in self:
+            zk = self._get_connection_object()
+            conn = self.device_connect(zk)
+            if not conn:
+                raise UserError(_("Unable to connect to device"))
+
+            try:
+                conn.disable_device()
+                # Pull from device
+                all_attendance = conn.get_attendance()
+
+                # Stage to zk.machine.attendance with unique constraint
+                for att in all_attendance:
+                    raw_ts = att.timestamp
+                    local_dt = device_tz.localize(raw_ts) if raw_ts.tzinfo is None else raw_ts.astimezone(device_tz)
+                    att_date = local_dt.date()
+                    # Only keep recent data (today by default)
+                    if att_date != today_local:
+                        continue
+                    employee = self.env['hr.employee'].search([('employee_number', '=', att.user_id)], limit=1)
+                    if not employee:
+                        continue
+                    utc_dt = local_dt.astimezone(pytz.utc)
+                    punching_time = fields.Datetime.to_string(utc_dt)
+                    if not zk_attendance.search([('device_id_num', '=', str(att.user_id)),
+                                                 ('punching_time', '=', punching_time)], limit=1):
+                        zk_attendance.create({
+                            'employee_id': employee.id,
+                            'device_id_num': str(att.user_id),
+                            'attendance_type': str(getattr(att, 'status', '1')),
+                            'punch_type': str(getattr(att, 'punch', '0')),
+                            'punching_time': punching_time,
+                            'address_id': info.address_id.id,
+                        })
+
+                # Process unprocessed punches for today
+                to_process = zk_attendance.search([
+                    ('processed', '=', False),
+                ])
+
+                for row in to_process:
+                    emp = row.employee_id
+                    if not emp:
+                        continue
+
+                    punch = fields.Datetime.from_string(row.punching_time)
+                    punch = pytz.utc.localize(punch) if punch.tzinfo is None else punch
+                    punch = punch.astimezone(device_tz)
+
+                    shift_type, slots = self._select_shift_type(emp, punch)
+
+                    # Idempotency: skip if already materialized
+                    punch_utc_str = fields.Datetime.to_string(punch.astimezone(pytz.utc))
+                    exists = hr_attendance.search(['|', ('check_in', '=', punch_utc_str), ('check_out', '=', punch_utc_str),
+                                                   ('employee_id', '=', emp.id)], limit=1)
+                    if exists:
+                        row.write({'processed': True, 'hr_attendance_id': exists.id})
+                        continue
+
+                    created_or_found_id = False
+
+                    if shift_type == 'day':
+                        first_start, first_end = slots[0]
+                        second_start, second_end = slots[1] if len(slots) > 1 else (None, None)
+
+                        if punch.time() <= first_end:
+                            created_or_found_id = hr_attendance.create({
+                                'employee_id': emp.id,
+                                'check_in': punch_utc_str,
+                            }).id
+                        elif second_start and first_end < punch.time() <= second_end:
+                            prev_att = hr_attendance.search([
+                                ('employee_id', '=', emp.id),
+                                ('check_out', '=', False),
+                                ('check_in', '!=', False),
+                                ('check_in', '>=', fields.Datetime.to_string(datetime.datetime.combine(punch.date(), datetime.time(0, 0))))
+                            ], order="check_in desc", limit=1)
+                            if prev_att:
+                                prev_att.write({'check_out': punch_utc_str})
+                                created_or_found_id = prev_att.id
+                            else:
+                                created_or_found_id = hr_attendance.create({
+                                    'employee_id': emp.id,
+                                    'check_in': punch_utc_str,
+                                }).id
+                        else:
+                            prev_att = hr_attendance.search([
+                                ('employee_id', '=', emp.id),
+                                ('check_out', '=', False)
+                            ], order="check_in desc", limit=1)
+                            if prev_att:
+                                prev_att.write({'check_out': punch_utc_str})
+                                created_or_found_id = prev_att.id
+                            else:
+                                created_or_found_id = hr_attendance.create({
+                                    'employee_id': emp.id,
+                                    'check_in': False,
+                                    'check_out': punch_utc_str,
+                                }).id
+
+                    else:
+                        # Night shift handling
+                        first_day_start = slots[0][0]
+                        second_day_end = slots[1][1] if len(slots) > 1 else slots[0][1]
+
+                        if punch.time() >= first_day_start:
+                            shift_start_dt = datetime.datetime.combine(punch.date(), first_day_start)
+                            shift_end_dt = datetime.datetime.combine(punch.date() + datetime.timedelta(days=1), second_day_end)
+                        else:
+                            shift_start_dt = datetime.datetime.combine(punch.date() - datetime.timedelta(days=1), first_day_start)
+                            shift_end_dt = datetime.datetime.combine(punch.date(), second_day_end)
+
+                        shift_start_dt = device_tz.localize(shift_start_dt)
+                        shift_end_dt = device_tz.localize(shift_end_dt)
+
+                        checkin_window_start = shift_start_dt - datetime.timedelta(hours=2)
+                        checkin_window_end = shift_start_dt + datetime.timedelta(hours=4)
+                        morning_checkout_cutoff = shift_end_dt + datetime.timedelta(hours=2)
+
+                        if checkin_window_start <= punch <= checkin_window_end:
+                            created_or_found_id = hr_attendance.create({
+                                'employee_id': emp.id,
+                                'check_in': punch_utc_str,
+                            }).id
+                        elif punch <= morning_checkout_cutoff:
+                            prev_att = hr_attendance.search([
+                                ('employee_id', '=', emp.id),
+                                ('check_out', '=', False)
+                            ], order="check_in desc", limit=1)
+                            if prev_att:
+                                prev_att.write({'check_out': punch_utc_str})
+                                created_or_found_id = prev_att.id
+                            else:
+                                created_or_found_id = hr_attendance.create({
+                                    'employee_id': emp.id,
+                                    'check_in': False,
+                                    'check_out': punch_utc_str,
+                                }).id
+                        else:
+                            prev_att = hr_attendance.search([
+                                ('employee_id', '=', emp.id),
+                                ('check_out', '=', False)
+                            ], order="check_in desc", limit=1)
+                            if prev_att:
+                                prev_att.write({'check_out': punch_utc_str})
+                                created_or_found_id = prev_att.id
+                            else:
+                                created_or_found_id = hr_attendance.create({
+                                    'employee_id': emp.id,
+                                    'check_in': False,
+                                    'check_out': punch_utc_str,
+                                }).id
+
+                    row.write({'processed': True, 'hr_attendance_id': created_or_found_id or False})
+
+            finally:
+                try:
+                    conn.enable_device()
+                except Exception:
+                    pass
+                try:
+                    conn.disconnect()
+                except Exception:
+                    pass
+
+        total_time = time.time() - start_time
+        _logger.info(f"Attendance download completed in {total_time:.2f} seconds.")
+        return True
+

--- a/models/zk_machine_attendance.py
+++ b/models/zk_machine_attendance.py
@@ -1,0 +1,27 @@
+from odoo import api, fields, models
+
+
+class ZkMachineAttendance(models.Model):
+    _name = 'zk.machine.attendance'
+    _description = 'Raw punches from biometric device'
+    _rec_name = 'punching_time'
+
+    employee_id = fields.Many2one('hr.employee', required=False, index=True)
+    device_id_num = fields.Char(string='Device User ID', required=True, index=True)
+    attendance_type = fields.Char(string='Attendance Type')
+    punch_type = fields.Char(string='Punch Type')
+    punching_time = fields.Datetime(string='Punching Time', required=True, index=True)
+    address_id = fields.Many2one('res.partner', string='Working Address')
+
+    # Idempotency helpers
+    processed = fields.Boolean(default=False, index=True)
+    hr_attendance_id = fields.Many2one('hr.attendance', string='Linked Attendance')
+
+    _sql_constraints = [
+        (
+            'uniq_device_punch',
+            'unique(device_id_num, punching_time)',
+            'This device punch is already stored.'
+        ),
+    ]
+

--- a/models/zk_machine_attendance.py
+++ b/models/zk_machine_attendance.py
@@ -1,17 +1,35 @@
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ZkMachineAttendance(models.Model):
+    """Model to hold data from the biometric device.
+    Inherits hr.attendance so we can optionally link/use those fields.
+    Also acts as a staging table with idempotency helpers.
+    """
     _name = 'zk.machine.attendance'
-    _description = 'Raw punches from biometric device'
+    _description = 'Attendance'
+    _inherit = 'hr.attendance'
     _rec_name = 'punching_time'
 
-    employee_id = fields.Many2one('hr.employee', required=False, index=True)
-    device_id_num = fields.Char(string='Device User ID', required=True, index=True)
-    attendance_type = fields.Char(string='Attendance Type')
-    punch_type = fields.Char(string='Punch Type')
-    punching_time = fields.Datetime(string='Punching Time', required=True, index=True)
-    address_id = fields.Many2one('res.partner', string='Working Address')
+    device_id_num = fields.Char(string='Biometric Device ID', help="The ID of the Biometric Device", index=True)
+    punch_type = fields.Selection([
+        ('0', 'Check In'), ('1', 'Check Out'),
+        ('2', 'Break Out'), ('3', 'Break In'),
+        ('4', 'Overtime In'), ('5', 'Overtime Out'),
+        ('255', 'Duplicate')],
+        string='Punching Type', help='Punching type of the attendance')
+
+    attendance_type = fields.Selection([
+        ('1', 'Finger'), ('15', 'Face'), ('2', 'Type_2'),
+        ('3', 'Password'), ('4', 'Card'), ('255', 'Duplicate')],
+        string='Category', help="Attendance detecting methods")
+
+    punching_time = fields.Datetime(string='Punching Time', help="Punching time in the device", index=True)
+    address_id = fields.Many2one('res.partner', string='Working Address', help="Working address of the employee")
+
+    late_minutes = fields.Integer(string='Late Minutes', default=0)
+    early_checkout_minutes = fields.Integer(string='Early Checkout Minutes', default=0)
 
     # Idempotency helpers
     processed = fields.Boolean(default=False, index=True)

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -2,3 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_attendance_dashboard_public,attendance_dashboard.public,base.model_res_users,,1,0,0,0
 access_hr_employee_public,hr.employee.public,hr.model_hr_employee,,1,0,0,0
 access_hr_attendance_public,hr.attendance.public,hr_attendance.model_hr_attendance,,1,0,0,0
+access_zk_machine_attendance_user,zk.machine.attendance.user,model_zk_machine_attendance,,1,1,1,0
+access_biometric_device_details_manager,biometric.device.details.manager,model_biometric_device_details,,1,1,1,0


### PR DESCRIPTION
Correctly process night-shift attendance punches and prevent duplicates from frequent cron runs.

This PR refines the biometric attendance import logic to accurately categorize punches for night shifts (e.g., treating morning punches as check-outs for the previous day's shift). It also introduces a staging table with unique constraints and idempotency checks to ensure that repeated cron executions do not create duplicate attendance records.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9a60264-027c-4591-99ed-11eb086683d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9a60264-027c-4591-99ed-11eb086683d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

